### PR TITLE
Fix Post Call

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -10,11 +10,11 @@ router.post('/new-contact', async (req, res) => {
 		email: req.body.email
 	});
 	try {
-		await newContact.save();
-		res.send(posts);
-	} catch {
+		response = await newContact.save();
+		res.send(response);
+	} catch (error) {
 		res.status(500);
-		res.send({ error: 'Failed to save new contact.' });
+		res.send({ error: `Failed to save new contact. Reason: ${error}` });
 	}
 });
 


### PR DESCRIPTION
**Bug**
- Was called `res.send(posts);` in the new-contact post call but `posts` was undefined.
- Error handling wasn't very clear

**Fix**
- Getting the response from the mongoose save call and sending that as response
```
   response = await newContact.save();
   res.send(response);
```
- Improved error handling by including the error from the catch